### PR TITLE
Fix invalid repo URL

### DIFF
--- a/HTools.sh
+++ b/HTools.sh
@@ -54,7 +54,8 @@ git clone https://github.com/mempodippy/vlany.git
 git clone https://github.com/unix-thrust/beurk.git
 git clone https://github.com/nmap/nmap.git
 git clone https://github.com/leviathan-framework/leviathan.git
-git clone https://github.com/n1nj4sec/pupy/tree/master/client
+# pupy repository (client and server)
+git clone https://github.com/n1nj4sec/pupy.git
 git clone https://github.com/valyala/goloris.git
 git clone https://github.com/radare/radare2.git
 git clone https://github.com/OffensivePython/Saddam.git


### PR DESCRIPTION
## Summary
- fix pupy repo clone URL in the tool collection script

## Testing
- `bash -n HTools.sh`


------
https://chatgpt.com/codex/tasks/task_e_684f9be3b7208320abe76f8c73b57e24