### PR TITLE
Fix pupy repository URL in HTools.sh

### DIFF
--- a/HTools.sh
+++ b/HTools.sh
@@ -54,7 +54,7 @@ git clone https://github.com/mempodippy/vlany.git
 git clone https://github.com/unix-thrust/beurk.git
 git clone https://github.com/nmap/nmap.git
 git clone https://github.com/leviathan-framework/leviathan.git
-git clone https://github.com/n1nj4sec/pupy/tree/master/client
+git clone https://github.com/n1nj4sec/pupy.git
 git clone https://github.com/valyala/goloris.git
 git clone https://github.com/radare/radare2.git
 git clone https://github.com/OffensivePython/Saddam.git


### PR DESCRIPTION
## Summary
- update pupy git clone URL in `HTools.sh`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f9c8d28948320ac3ac666e24d61c6